### PR TITLE
Add Amplitude event consumer

### DIFF
--- a/consumers/amplitude/Dockerfile
+++ b/consumers/amplitude/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY *.py *.sh ./
+
+ENTRYPOINT [ "python" ]
+CMD [ "./receive_events.py" ]

--- a/consumers/amplitude/build.sh
+++ b/consumers/amplitude/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t event-worker:amplitude .

--- a/consumers/amplitude/emit_event.py
+++ b/consumers/amplitude/emit_event.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import pika
+import sys
+
+# TODO: Read from ENV
+queueName = 'event.sink'
+exchangeName = 'clowder.metrics'
+
+message = ' '.join(sys.argv[1:]) or "Hello World!"
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+try:
+    channel = connection.channel()
+
+    channel.exchange_declare(exchange=exchangeName, exchange_type='fanout')
+
+    channel.basic_publish(exchange=exchangeName, routing_key='', body=message,
+                      properties=pika.BasicProperties(
+                         delivery_mode = 2, # make message persistent
+                      ))
+
+    print(" [x] Sent %r" % message)
+finally:
+    connection.close()

--- a/consumers/amplitude/receive_events.py
+++ b/consumers/amplitude/receive_events.py
@@ -81,7 +81,8 @@ channel = connection.channel()
 
 # Declare an exchange and a durable queue for our event fanout
 channel.exchange_declare(exchange=exchangeName,
-                         exchange_type='fanout')
+                         exchange_type='fanout',
+                         durable=True)
 channel.queue_declare(queue=queueName, durable=True)
 channel.queue_bind(exchange=exchangeName, queue=queueName)
 

--- a/consumers/amplitude/receive_events.py
+++ b/consumers/amplitude/receive_events.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+import os
+import pika
+import time
+import requests
+
+# DEBUG: Remove me
+#import logging
+#import contextlib
+#try:
+#    from http.client import HTTPConnection # py3
+#except ImportError:
+#    from httplib import HTTPConnection # py2
+#
+#HTTPConnection.debuglevel = 1
+#logging.basicConfig()
+#logging.getLogger().setLevel(logging.DEBUG)
+#requests_log = logging.getLogger("requests.packages.urllib3")
+#requests_log.setLevel(logging.DEBUG)
+#requests_log.propagate = True
+
+# TODO: Read from ENV
+queueName = 'event.sink'
+exchangeName = 'clowder.metrics'
+
+# FIXME: Fail-fast if no apikey is provided
+amplitudeApiKey = os.getenv('AMPLITUDE_API_KEY', '') 
+
+# Define what work to do with each message
+def callback(ch, method, properties, body):
+    print(" [x] Received %r" % body.decode())
+
+    # FIXME: Expand message to include missing required fields
+    millis = int(round(time.time() * 1000))
+    message = { 
+      "created": millis,
+      "message": body.decode(),
+      "user_id": "example",
+      "device_id": "example"
+    }
+
+    # TODO: Different fields here?
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "*/*",
+    }
+    json = {
+        "api_key": amplitudeApiKey,
+        "events": [
+            {
+               # Required fields
+               # FIXME: How to populate these?
+               "event_type": "example",
+               "user_id": os.getenv('AMPLITUDE_USER_ID', message['user_id']),
+               "device_id": os.getenv('AMPLITUDE_DEVICE_ID', message['device_id']),
+
+               # FIXME: 
+               "time": message['created'],
+               "event_properties": {
+                   "message": message['message']
+               }
+            }
+        ],
+        "options": {
+            "min_id_length": os.getenv('AMPLITUDE_MIN_ID_LENGTH', 0),
+        }
+    } 
+
+    # Send POST, print response
+    msg = requests.post('https://api2.amplitude.com/batch', json=json, headers=headers)
+    print(msg.text)
+
+    # Acknowledge message in RabbitMQ
+    print(" [x] Done writing to Amplitude" )
+    ch.basic_ack(delivery_tag = method.delivery_tag)
+
+
+# Connect to RabbitMQ
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+# Declare an exchange and a durable queue for our event fanout
+channel.exchange_declare(exchange=exchangeName,
+                         exchange_type='fanout')
+channel.queue_declare(queue=queueName, durable=True)
+channel.queue_bind(exchange=exchangeName, queue=queueName)
+
+# Only fetch/work on one message at a time
+channel.basic_qos(prefetch_count=1)
+channel.basic_consume(queue=queueName,
+                      on_message_callback=callback)
+
+
+# Wait for messages
+print(' [*] Waiting for messages. To exit press CTRL+C')
+channel.start_consuming()
+
+
+# Error-handling / clean-up
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Interrupted, cleaning up... Press Ctrl+C again to exit immediately.')
+        try:
+            sys.exit(0)
+        except SystemExit:
+            os._exit(0)
+    finally:
+        if connection is not None:
+            connection.close()
+

--- a/consumers/amplitude/recv.sh
+++ b/consumers/amplitude/recv.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --net=host -e AMPLITUDE_API_KEY=${AMPLITUDE_API_KEY} -it --rm event-worker:amplitude

--- a/consumers/amplitude/requirements.txt
+++ b/consumers/amplitude/requirements.txt
@@ -1,0 +1,2 @@
+pika
+requests

--- a/consumers/amplitude/send.sh
+++ b/consumers/amplitude/send.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --net=host -it --rm event-worker:amplitude /usr/src/emit_event.py $@


### PR DESCRIPTION
## How to Test
Prerequisite: RabbitMQ running locally

1. Set `AMPLITUDE_API_KEY`:
    * `export AMPLITUDE_API_KEY=123456789012345678901234567890`
2. Start up one or more Amplitude consumer and send a test message:
    * Terminal A: `./recv.sh`
    * Terminal B: `./send.sh`
3. Log into your organization within Amplitude
4. Add a new chart filtering All Events
5. Select your project and "Event Segmentation" from the dropdowns at the top
    * You should see a graph appear below
    * You should see at least one point on the graph, if step 2 completed successfully
6. Click the point on the graph and choose "View User Streams"
    * A modal window should open
    * You should be able to see a stream of the events received (`event_type` is displayed, this is currently "example" by default)
7. Click on one of the "example" events
    * You should be brought to a more detailed view for this event, showing all internal values
    * Scrolling down, you should see the `user_id` and `device_id` are currently "example" - how do we populate these in the backend? Does the EventSinkService need to send these?
    * Scrolling down further, you should see the `message` that was sent (by default, this is ["Hello World!"](https://github.com/clowder-framework/event-sink-consumers/blob/amplitude/consumers/amplitude/emit_event.py#L9))