### PR TITLE
Adding Google Analytics to consumers

### DIFF
--- a/consumers/google-analytics-4/Dockerfile
+++ b/consumers/google-analytics-4/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY *.py *.sh ./
+
+ENTRYPOINT [ "python" ]
+CMD [ "./receive_events.py" ]

--- a/consumers/google-analytics-4/README.md
+++ b/consumers/google-analytics-4/README.md
@@ -1,0 +1,33 @@
+# How to test
+
+### 1. Set Environment Variables
+Set the following env variables filling in the necessary values:
+- export GOOGLE_API_SECRET="<secret_value>"
+- export GOOGLE_MEASUREMENT_ID="G-XXXXX"
+- export GOOGLE_CLIENT_ID="12345678901"
+
+To create an api secret for your project, on your Google Analytics dashboard go to:
+- Admin > Data Streams > choose your stream > Measurement Protocol > Create
+
+To find you measurement id on your google analytics dashboard go to:
+- Admin > Data Streams > choose your stream > Measurement ID
+
+The client_id is a unique id.
+
+### 2. Build Docker image locally
+
+In a terminal: ./build.sh
+
+### 3. Start up one or more Google Analytics consumer and send a test message:
+
+- Terminal A: ./recv.sh
+- Terminal B: ./send.sh
+
+### 4. Confirm event in Google Analytics
+1. Log into your Google Analytics dashboard and click on the appropriate project.
+3. Navigate to the Realtime tab.
+- Scroll down to event count by event_name panel. You should see the event "test_event" if step 3 completed successfully
+4. Click on the event named "test_event."
+- The event parameters should now be displayed in the same panel.
+5. Click on the "message" parameter.
+- You should be able to see "Hello World!" as the value for the message parameter.

--- a/consumers/google-analytics-4/README.md
+++ b/consumers/google-analytics-4/README.md
@@ -31,3 +31,7 @@ In a terminal: ./build.sh
 - The event parameters should now be displayed in the same panel.
 5. Click on the "message" parameter.
 - You should be able to see "Hello World!" as the value for the message parameter.
+
+### 5. To-dos
+1. More fully work out way to send full event JSON and configure event parameters, user_properties,etc.
+2. Add user_properties

--- a/consumers/google-analytics-4/build.sh
+++ b/consumers/google-analytics-4/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t event-worker:google-analytics .

--- a/consumers/google-analytics-4/emit_event.py
+++ b/consumers/google-analytics-4/emit_event.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import pika
+import sys
+
+# TODO: Read from ENV
+queueName = 'event.sink'
+exchangeName = 'clowder.metrics'
+
+message = ' '.join(sys.argv[1:]) or "Hello World!"
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+try:
+    channel = connection.channel()
+
+    channel.exchange_declare(exchange=exchangeName, exchange_type='fanout')
+
+    channel.basic_publish(exchange=exchangeName, routing_key='', body=message,
+                      properties=pika.BasicProperties(
+                         delivery_mode = 2, # make message persistent
+                      ))
+
+    print(" [x] Sent %r" % message)
+finally:
+    connection.close()

--- a/consumers/google-analytics-4/receive_events.py
+++ b/consumers/google-analytics-4/receive_events.py
@@ -28,7 +28,7 @@ def callback(ch, method, properties, body):
 
     # TODO: Different fields here?
     headers = {
-        "Content-Type": "application/json; charset=utf-8",
+        "Content-Type": "application/json",
         "Accept": "*/*",
     }
 

--- a/consumers/google-analytics-4/receive_events.py
+++ b/consumers/google-analytics-4/receive_events.py
@@ -65,7 +65,8 @@ channel = connection.channel()
 
 # Declare an exchange and a durable queue for our event fanout
 channel.exchange_declare(exchange=exchangeName,
-                         exchange_type='fanout')
+                         exchange_type='fanout',
+                         durable=True)
 channel.queue_declare(queue=queueName, durable=True)
 channel.queue_bind(exchange=exchangeName, queue=queueName)
 

--- a/consumers/google-analytics-4/receive_events.py
+++ b/consumers/google-analytics-4/receive_events.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+import os
+import pika
+import time
+import requests
+import json
+
+# TODO: Read from ENV
+queueName = 'event.sink'
+exchangeName = 'clowder.metrics'
+
+# FIXME: Fail-fast if no apikey is provided
+GoogleApiSecret = os.getenv('GOOGLE_API_SECRET', '') 
+GoogleMeasurementId = os.getenv('GOOGLE_MEASUREMENT_ID', '')
+GoogleClientId = os.getenv('GOOGLE_CLIENT_ID','')
+
+# Define what work to do with each message
+def callback(ch, method, properties, body):
+    print(" [x] Received %r" % body.decode())
+
+    # FIXME: Expand message to include missing required fields
+    millis = int(round(time.time() * 1000))
+    message = { 
+      "created": millis,
+      "message": body.decode(),
+      "client_id": "example",
+    }
+
+    # TODO: Different fields here?
+    headers = {
+        "Content-Type": "application/json; charset=utf-8",
+        "Accept": "*/*",
+    }
+
+    params = {
+        "api_secret": GoogleApiSecret,
+        "measurement_id": GoogleMeasurementId,
+    }
+    
+    event_json = {
+        "client_id": os.getenv('GOOGLE_CLIENT_ID', message['client_id']),
+        "events": [
+            {
+               # Required fields
+               "name": "test_event",
+               "params": {
+                   "message": message['message']
+               }
+            }
+        ],
+        }
+
+    # Send POST, print response
+    msg = requests.post('https://google-analytics.com/mp/collect', params=params, json=event_json, headers=headers)
+    print(msg.text)
+
+    # Acknowledge message in RabbitMQ
+    print(" [x] Done writing to Google Analytics" )
+    ch.basic_ack(delivery_tag = method.delivery_tag)
+
+
+# Connect to RabbitMQ
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+# Declare an exchange and a durable queue for our event fanout
+channel.exchange_declare(exchange=exchangeName,
+                         exchange_type='fanout')
+channel.queue_declare(queue=queueName, durable=True)
+channel.queue_bind(exchange=exchangeName, queue=queueName)
+
+# Only fetch/work on one message at a time
+channel.basic_qos(prefetch_count=1)
+channel.basic_consume(queue=queueName,
+                      on_message_callback=callback)
+
+
+# Wait for messages
+print(' [*] Waiting for messages. To exit press CTRL+C')
+channel.start_consuming()
+
+
+# Error-handling / clean-up
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Interrupted, cleaning up... Press Ctrl+C again to exit immediately.')
+        try:
+            sys.exit(0)
+        except SystemExit:
+            os._exit(0)
+    finally:
+        if connection is not None:
+            connection.close()
+

--- a/consumers/google-analytics-4/recv.sh
+++ b/consumers/google-analytics-4/recv.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --net=host -e GOOGLE_API_SECRET=${GOOGLE_API_SECRET} -e GOOGLE_MEASUREMENT_ID=${GOOGLE_MEASUREMENT_ID} -e GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID} -it --rm event-worker:google-analytics

--- a/consumers/google-analytics-4/requirements.txt
+++ b/consumers/google-analytics-4/requirements.txt
@@ -1,0 +1,2 @@
+pika
+requests

--- a/consumers/google-analytics-4/send.py
+++ b/consumers/google-analytics-4/send.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import pika
+import sys
+
+
+message = ' '.join(sys.argv[1:]) or "Hello World!"
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+queueName = 'event.sink'
+try:
+    channel = connection.channel()
+
+    channel.queue_declare(queue=queueName, durable=True)
+
+    channel.basic_publish(exchange='',
+                      routing_key=queueName,
+                      body=message)
+
+    print(" [x] Sent %r" % message)
+finally:
+    connection.close()

--- a/consumers/google-analytics-4/send.sh
+++ b/consumers/google-analytics-4/send.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --net=host -it --rm event-worker:google-analytics /usr/src/emit_event.py $@


### PR DESCRIPTION

# How to test

### 1. Set Environment Variables
Set the following env variables filling in the necessary values:
- export GOOGLE_API_SECRET="<secret_value>"
- export GOOGLE_MEASUREMENT_ID="G-XXXXX"
- export GOOGLE_CLIENT_ID="12345678901"

To create an api secret for your project, on your Google Analytics dashboard go to:
- Admin > Data Streams > choose your stream > Measurement Protocol > Create

To find you measurement id on your google analytics dashboard go to:
- Admin > Data Streams > choose your stream > Measurement ID

The client_id is a unique id.

### 2. Build Docker image locally

In a terminal: ./build.sh

### 3. Start up one or more Google Analytics consumer and send a test message:

- Terminal A: ./recv.sh
- Terminal B: ./send.sh

### 4. Confirm event in Google Analytics
1. Log into your Google Analytics dashboard and click on the appropriate project.
3. Navigate to the Realtime tab.
- Scroll down to event count by event_name panel. You should see the event "test_event" if step 3 completed successfully
4. Click on the event named "test_event."
- The event parameters should now be displayed in the same panel.
5. Click on the "message" parameter.
- You should be able to see "Hello World!" as the value for the message parameter.