### PR TITLE
InfluxDB wouldn't accept "service_name" as a tag for some reason

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker
 # This will run when:
 # - a new release is created, to make sure the right tags of the
 #   docker images are pushed (expects tags to be v1.8.4).
-# - when new code is pushed to master/develop to push the tags
+# - when new code is pushed to main/develop to push the tags
 #   latest and develop
 # - when a pull request is created and updated  to make sure the
 #   Dockerfile is still valid.
@@ -14,11 +14,11 @@ name: Docker
 on:
   push:
     branches:
-      - master
+      - main
 
   pull_request:
 
-# Certain actions will only run when this is the master repo.
+# Certain actions will only run when this is the main repo.
 env:
   MASTER_REPO: clowder-framework/event-sink-consumers
   DOCKERHUB_ORG: clowder

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,120 @@
+name: Docker
+
+# This will run when:
+# - a new release is created, to make sure the right tags of the
+#   docker images are pushed (expects tags to be v1.8.4).
+# - when new code is pushed to master/develop to push the tags
+#   latest and develop
+# - when a pull request is created and updated  to make sure the
+#   Dockerfile is still valid.
+# To be able to push to dockerhub, this execpts the following
+# secrets to be set in the project:
+# - DOCKERHUB_USERNAME : username that can push to the org
+# - DOCKERHUB_PASSWORD : password asscoaited with the username
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+# Certain actions will only run when this is the master repo.
+env:
+  MASTER_REPO: clowder-framework/event-sink-consumers
+  DOCKERHUB_ORG: clowder
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        name:
+          - echo
+          - mongodb
+          - influxdb
+          - amplitude
+          - google-analytics
+        include:
+          - name: echo
+            FOLDER: consumers/echo
+          - name: mongodb
+            FOLDER: consumers/mongodb
+          - name: influxdb
+            FOLDER: consumers/influxdb
+          - name: amplitude
+            FOLDER: consumers/amplitude
+          - name: google-analytics
+            FOLDER: consumers/google-analytics-4
+    steps:
+      - uses: actions/checkout@v2
+
+      # build the docker image, this will always run to make sure
+      # the Dockerfile still works.
+      - name: Build image
+        uses: elgohr/Publish-Docker-Github-Action@2.22
+        env:
+          VERSION: ${{ env.VERSION }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
+        with:
+          registry: docker.pkg.github.com
+          name: ${{ github.repository_owner }}/${{ github.event.repository.name }}/eventsink-${{ matrix.NAME }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          context: ${{ matrix.FOLDER }}
+          tags: "${{ env.TAGS }}"
+          buildargs: VERSION,BUILDNUMBER,GITSHA1
+          no_push: true
+
+      # this will publish to github container registry
+      - name: Publish to GitHub
+        if: github.event_name == 'push' && github.repository == env.MASTER_REPO
+        uses: elgohr/Publish-Docker-Github-Action@2.22
+        env:
+          VERSION: ${{ env.VERSION }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
+        with:
+          registry: ghcr.io
+          name: ${{ github.repository_owner }}/eventsink-${{ matrix.NAME }}
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PASSWORD }}
+          context: ${{ matrix.FOLDER }}
+          tags: "${{ env.TAGS }}"
+          buildargs: VERSION,BUILDNUMBER,GITSHA1
+
+      # this will publish to the clowder dockerhub repo
+      - name: Publish to Docker Hub
+        if: github.event_name == 'push' && github.repository == env.MASTER_REPO
+        uses: elgohr/Publish-Docker-Github-Action@2.22
+        env:
+          VERSION: ${{ env.VERSION }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
+        with:
+          name: ${{ env.DOCKERHUB_ORG }}/eventsink-${{ matrix.NAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          context: ${{ matrix.FOLDER }}
+          tags: "${{ env.TAGS }}"
+          buildargs: VERSION,BUILDNUMBER,GITSHA1
+
+      # this will update the README of the dockerhub repo
+      - name: check file
+        id: filecheck
+        if: github.event_name != 'push' && github.repository == env.MASTER_REPO
+        run: |
+          if [ "${{ matrix.README }}" != "" -a -e "${{ matrix.README }}" ]; then
+            echo "##[set-output name=exists;]true"
+          else
+            echo "##[set-output name=exists;]false"
+          fi
+      - name: Docker Hub Description
+        if: github.event_name != 'push' && github.repository == env.MASTER_REPO && steps.filecheck.outputs.exists == 'true'
+        uses: peter-evans/dockerhub-description@v2
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: ${{ env.DOCKERHUB_ORG }}/eventsink-${{ matrix.NAME }}
+          README_FILEPATH: ${{ matrix.README }}

--- a/consumers/influxdb/emit_event.py
+++ b/consumers/influxdb/emit_event.py
@@ -11,7 +11,7 @@ connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
 try:
     channel = connection.channel()
 
-    channel.exchange_declare(exchange=exchangeName, exchange_type='fanout')
+    channel.exchange_declare(exchange=exchangeName, exchange_type='fanout', durable=True)
 
     channel.basic_publish(exchange=exchangeName, routing_key='', body=message,
                       properties=pika.BasicProperties(

--- a/consumers/influxdb/emit_event.py
+++ b/consumers/influxdb/emit_event.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 import pika
 import sys
+import time
 
 # TODO: Read from ENV
 queueName = 'event.sink'
 exchangeName = 'clowder.metrics'
 
-message = ' '.join(sys.argv[1:]) or "Hello World!"
+millis = int(round(time.time() * 1000))
+message = ' '.join(sys.argv[1:]) or '{"created":%s,"category":"service_status","type":"up","service_name":"clowder"}' % (millis)
 connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
 try:
     channel = connection.channel()

--- a/consumers/influxdb/receive_events.py
+++ b/consumers/influxdb/receive_events.py
@@ -33,7 +33,7 @@ client.switch_database(databaseName)
 def callback(ch, method, properties, body):
     print(" [x] Received %r" % body.decode())
 
-    event = json.loads(body.decode())
+    event = json.loads(body.decode()) 
 
     tags = {}
     fields = {}
@@ -43,8 +43,6 @@ def callback(ch, method, properties, body):
         tags['type'] = event['type']
     if ('category' in event):
         tags['category'] = event['category']
-    if ('service_name' in event):
-        tags['service_name'] = event['service_name']
     if ('user_id' in event):
         tags['user_id'] = event['user_id']
     if ('author_id' in event):
@@ -57,6 +55,8 @@ def callback(ch, method, properties, body):
         fields['resource_id'] = event['resource_id']
     if ('dataset_id' in event):
         fields['dataset_id'] = event['dataset_id']
+    if ('service_name' in event):
+        fields['service_name'] = event['service_name']
     if ('dataset_name' in event):
         fields['dataset_name'] = event['dataset_name']
     if ('author_name' in event):


### PR DESCRIPTION
## Problem
InfluxDB complains about using `service_name` as a tag:
```python
influxdb.exceptions.InfluxDBClientError: 400: {"error":"unable to parse 'events,category=service_status,service_name=clowder,type=up 1615969801199': invalid field format"}
```

## Approach
* Change `service_name` from a tag to a field to appease InfluxDB
* Add GitHub actions to automate Docker build/push

## How to Test
Prerequisite: Clowder running, RabbitMQ running, InfluxDB running, external-event-bus deployed

1. Checkout and run this branch locally
2. Build and run this branch of the InfluxDB consumer: `./build.sh && ./recv.sh`
3. Checkout, build, and run the matching branch of the external-event-bus: `docker run -itd --name flask --env-file .env -p 5000:5000 simpl-eventbus-api && docker logs -f flask`
4. Send a `curl` request to the Flask API: `curl localhost:5000/service -XPOST --header 'API-KEY: r1ek3rs'`
    * You should see a new event come in through the InfluxDB eventsink consumer logs
5. Verify that the event now appears in InfluxDB:
```bash
$ docker exec -it influxdb bash
root@d539dfeb65e5:/# influx
Connected to http://localhost:8086 version 1.8.3
InfluxDB shell version: 1.8.3
> use eventsink
Using database eventsink
> select category,service_name,type from events where category='service_status';
name: events
time          category       service_name type
----          --------       ------------ ----
1615969801199 service_status clowder      up
1615971711668 service_status clowder      up
1615971742608 service_status clowder      up
1615971743291 service_status clowder      up
1615971762397 service_status clowder      up
```