### PR TITLE
Tune logging and parse for precision

### DIFF
--- a/consumers/influxdb/receive_events.py
+++ b/consumers/influxdb/receive_events.py
@@ -86,7 +86,7 @@ def callback(ch, method, properties, body):
     # Parse timestamp, if necessary
     created_timestamp = event['created']
     time_precision = None
-    if isintance(created_timestamp, str):
+    if isinstance(created_timestamp, str):
         # Assume this is a date in ~ISO format, convert to millis
         created_datetime = dateutil.parser.isoparse('2008-09-03T20:56:35.450686Z')
         epoch = datetime.datetime.utcfromtimestamp(0)
@@ -100,12 +100,12 @@ def callback(ch, method, properties, body):
         if digit_count <= 11:
             # epoch timestamp has ~10 digits - assume that it is given in "seconds"
             time_precision = 's'
-        elif digit_count <= 14 && digit_count >= 12:
+        elif digit_count <= 14 and digit_count >= 12:
             time_precision = 'ms'
-        elif digit_count <= 17 && digit_count >= 15:
+        elif digit_count <= 17 and digit_count >= 15:
             time_precision = 'u'
     else:
-        logger.error('Unrecognized timestamp format: ' + str(created_timestamp)))
+        logger.error('Unrecognized timestamp format: ' + str(created_timestamp))
         
 
     # Write event as a data point in InfluxDB

--- a/consumers/influxdb/receive_events.py
+++ b/consumers/influxdb/receive_events.py
@@ -9,6 +9,7 @@ from influxdb import InfluxDBClient
 
 name = 'InfluxDBConsumer'
 logger = logging.getLogger(name)
+#logger.setLevel(logging.DEBUG)
 
 # RabbitMQ connection parameters
 RABBITMQ_URI = os.getenv('RABBITMQ_URI', 'amqp://guest:guest@rabbitmq/%2F')
@@ -88,7 +89,7 @@ def callback(ch, method, properties, body):
     time_precision = None
     if isinstance(created_timestamp, str):
         # Assume this is a date in ~ISO format, convert to millis
-        created_datetime = dateutil.parser.isoparse('2008-09-03T20:56:35.450686Z')
+        created_datetime = dateutil.parser.isoparse(created_timestamp)
         epoch = datetime.datetime.utcfromtimestamp(0)
         time = (created_datetime - epoch).total_seconds() * 1000.0
         time_precision = 'ms'


### PR DESCRIPTION
## Problem
Time series data is inserted into InfluxDB with incorrect precision. By default, InfluxDB / Grafana expect timestamps in nanoseconds. Clowder currently sends timestamps in seconds.

## Approach
* To prevent inconsistency, parse int timestamps to include `time_precision` when writing points to InfluxDB
* Replace calls to `print` with calls to Python's `logging` module
* Add (experimental) handling for future parsing of ISO dates from these messages

## How to Test
1. Run InfluxDB: `docker run -itd --name=influxdb -p 8086:8086 -v $PWD/influxdb:/var/lib/influxdb influxdb:1.8.4`
2. Run RabbitMQ: `docker run -itd --name=rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:management-alpine`
3. Checkout and run this branch locally: `git clone https://github.com/clowder-framework/event-sink-consumers; cd event-sink-consumers/consumers/influxdb && git fetch --all && git checkout tune-logging-and-parse-for-precision`
4. Set environment vars to point to RabbitMQ / InfluxDB: `vi .env`
5. Build and run the InfluxDB consumer: `./build.sh && ./recv.sh`
6. In another terminal window, send a test message: `./send.sh`
7. View the test data in InfluxDB:
```bash


```